### PR TITLE
Remove zinc.cool url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 This is a simple proxy around the cothority conodes, useful until they support wss:// connection.
 
-See it live and use it at [zinc.cool](https://zinc.cool/).
-
 ## Options
 
 When doing a query, zinc will automatically connect to the `dedis` cothority network.


### PR DESCRIPTION
I shut down the server (the project is on hold) so I removed the URL link from the description.